### PR TITLE
declare ownerStatement variable

### DIFF
--- a/javascript/lesson-2-variables-datatypes.md
+++ b/javascript/lesson-2-variables-datatypes.md
@@ -101,7 +101,8 @@ More examples:
 ```
 let carModel = "Jaguar XF";
 let carOwner = "Jane";
-console.log(`The owner of this ${carModel} car is ${carOwner}`);
+let ownerStatement = "The owner of this ${carModel} car is ${carOwner}"
+console.log(ownerStatement);
 let statementUpper = ownerStatement.toLocaleUpperCase();
 let statementlength = statementUpper.length;
 console.log(statementlength);


### PR DESCRIPTION
## What?
I fixed 'ownerStatement is not defined' error by declaring an ownerStatement variable.

## Why?
These changes allow for following expressions utilising the ownerStatement variable without producing an error